### PR TITLE
Change the meaning of return in VsyncMode

### DIFF
--- a/project/include/ui/Window.h
+++ b/project/include/ui/Window.h
@@ -32,7 +32,7 @@ namespace lime {
 			virtual ~Window () {};
 
 			virtual void Alert (const char* message, const char* title) = 0;
-			virtual bool SetVSyncMode (WindowVSyncMode mode) = 0;
+			virtual bool SetVSyncMode (int mode) = 0;
 			virtual void Close () = 0;
 			virtual void ContextFlip () = 0;
 			virtual void* ContextLock (bool useCFFIValue) = 0;

--- a/project/src/backend/sdl/SDLWindow.cpp
+++ b/project/src/backend/sdl/SDLWindow.cpp
@@ -348,10 +348,12 @@ namespace lime {
 	}
 
 
-	bool SDLWindow::SetVSyncMode (WindowVSyncMode mode) {
-
-		return SDL_GL_SetSwapInterval (mode);
-
+	bool SDLWindow::SetVSyncMode (int mode) {
+		
+		int res = SDL_GL_SetSwapInterval (mode);
+		
+		return res == mode || res == 0; // 0 sometimes means a success on some contexts?
+		
 	}
 
 

--- a/project/src/backend/sdl/SDLWindow.cpp
+++ b/project/src/backend/sdl/SDLWindow.cpp
@@ -349,11 +349,8 @@ namespace lime {
 
 
 	bool SDLWindow::SetVSyncMode (int mode) {
-		
 		int res = SDL_GL_SetSwapInterval (mode);
-		
 		return res == mode || res == 0; // 0 sometimes means a success on some contexts?
-		
 	}
 
 

--- a/project/src/backend/sdl/SDLWindow.h
+++ b/project/src/backend/sdl/SDLWindow.h
@@ -19,7 +19,7 @@ namespace lime {
 			~SDLWindow ();
 
 			virtual void Alert (const char* message, const char* title);
-			virtual bool SetVSyncMode (WindowVSyncMode mode);
+			virtual bool SetVSyncMode (int mode);
 			virtual void Close ();
 			virtual void ContextFlip ();
 			virtual void* ContextLock (bool useCFFIValue);


### PR DESCRIPTION
Changed the `SDLWindow::SetVSyncMode` to more accurately depict what the SDL Wiki says the function does.

This fixes VSync in projects using this fork.