### PR TITLE
Remove neko target configuration

### DIFF
--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -782,13 +782,6 @@ class HXProject extends Script
 				defines.set("cpp", "1");
 				defines.set("mingw", "1");
 			}
-			else
-			{
-				targetFlags.set("neko", "1");
-
-				defines.set("targetType", "neko");
-				defines.set("neko", "1");
-			}
 		}
 		else if (target == Platform.WEB_ASSEMBLY)
 		{


### PR DESCRIPTION
Nobody uses neko, please stop making me use neko. Thank you.

Basically, when trying to compile for Mac or IOS on windows, this would cause it to use neko, instead of being able to compile (without actually building, IE generating a .xml for types)