### PR TITLE
[FEATURE] Adaptive Icons on Apple Targets

### DIFF
--- a/src/lime/tools/AdaptiveIcon.hx
+++ b/src/lime/tools/AdaptiveIcon.hx
@@ -5,7 +5,7 @@ import haxe.io.Path;
 
 /**
 	This file is a wrapper to save to path and some properties about the AdaptiveIcon format from Android
-	It is also used to store Apple's Icon Composer .icon file for iOS since its also a dynamic icon file
+	It is also used to store Apple's Icon Composer .icon file for Apple Platforms as it is also a dynamic icon file
 **/
 class AdaptiveIcon
 {
@@ -18,7 +18,7 @@ class AdaptiveIcon
 		this.path = path;
 		this.hasRoundIcon = hasRoundIcon;
 
-		// macOS files are actually folders with a file extension
+		// Some macOS files are actually folders with a file extension and the icon composer file is one of them
 		this.iconComposerFile = Path.extension(path) == "icon" && FileSystem.isDirectory(path);
 	}
 

--- a/src/lime/tools/AdaptiveIcon.hx
+++ b/src/lime/tools/AdaptiveIcon.hx
@@ -1,14 +1,25 @@
 package lime.tools;
 
+import sys.FileSystem;
+import haxe.io.Path;
+
+/**
+	This file is a wrapper to save to path and some properties about the AdaptiveIcon format from Android
+	It is also used to store Apple's Icon Composer .icon file for iOS since its also a dynamic icon file
+**/
 class AdaptiveIcon
 {
 	public var path:String;
-	public var hasRoundIcon:Bool;
+	public var hasRoundIcon:Bool; // No use on iOS
+	public var iconComposerFile:Bool; // No use on Android
 
 	public function new(path:String, hasRoundIcon:Bool)
 	{
 		this.path = path;
 		this.hasRoundIcon = hasRoundIcon;
+
+		// macOS files are actually folders with a file extension
+		this.iconComposerFile = Path.extension(path) == "icon" && FileSystem.isDirectory(path);
 	}
 
 	public function clone():AdaptiveIcon

--- a/templates/ios/template/{{app.file}}.xcodeproj/project.pbxproj
+++ b/templates/ios/template/{{app.file}}.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1EF0A83A121ADB8E003F2F59 /* Main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1EF0A839121ADB8E003F2F59 /* Main.mm */; };
 		4257533F1A5EFD8C004AA45B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4257533E1A5EFD8C004AA45B /* Images.xcassets */; };
 		::if (IOS_LAUNCH_STORYBOARD != null)::D099CA9021A64C87003837AD /* ::IOS_LAUNCH_STORYBOARD::.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D099CA8F21A64C86003837AD /* ::IOS_LAUNCH_STORYBOARD::.storyboard */; };::end::
+		::if (IOS_ADAPTIVE_ICON != null)::D4E8A1F09C3B47E2F6A5D0BC /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = A7F3C9201B8E4D6FA1C2B7D9 /* AppIcon.icon */; };::end::
 		::ADDL_PBX_BUILD_FILE::
 
 /* End PBXBuildFile section */
@@ -48,6 +49,7 @@
 		4257533E1A5EFD8C004AA45B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "::APP_FILE::/Images.xcassets"; sourceTree = "<group>"; };
 		6662F3920A0E282007F4E3E /* ::APP_FILE::.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = "::APP_FILE::.entitlements"; path = "::APP_FILE::/::APP_FILE::.entitlements"; sourceTree = "<group>"; };
 		::if (IOS_LAUNCH_STORYBOARD != null)::D099CA8F21A64C86003837AD /* ::IOS_LAUNCH_STORYBOARD::.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "::APP_FILE::/::IOS_LAUNCH_STORYBOARD::.storyboard"; sourceTree = "<group>"; };::end::
+		::if (IOS_ADAPTIVE_ICON != null)::A7F3C9201B8E4D6FA1C2B7D9 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = file; path = "::APP_FILE::/AppIcon.icon"; sourceTree = "<group>"; };::end::
 		::ADDL_PBX_FILE_REFERENCE::
 
 		8D1107310486CEB800E47090 /* ::APP_FILE::-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "::APP_FILE::/::APP_FILE::-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 			children = (
 				4257533E1A5EFD8C004AA45B /* Images.xcassets */,
 				::if (IOS_LAUNCH_STORYBOARD != null)::D099CA8F21A64C86003837AD /* ::IOS_LAUNCH_STORYBOARD::.storyboard */,::end::
+				::if (IOS_ADAPTIVE_ICON != null)::A7F3C9201B8E4D6FA1C2B7D9 /* AppIcon.icon */,::end::
 				8D1107310486CEB800E47090 /* ::APP_FILE::/::APP_FILE::-Info.plist */,
 				1E2E17A5131E8B5D0048F3C7 /* ::APP_FILE::/assets */,
 				::ADDL_PBX_RESOURCE_GROUP::
@@ -195,6 +198,7 @@
 			files = (
 				1E2E17AD131E8B5D0048F3C7 /* ::APP_FILE::/assets in Resources */,
 				::if (IOS_LAUNCH_STORYBOARD != null)::D099CA9021A64C87003837AD /* ::IOS_LAUNCH_STORYBOARD::.storyboard in Resources */,::end::
+				::if (IOS_ADAPTIVE_ICON != null)::D4E8A1F09C3B47E2F6A5D0BC /* AppIcon.icon in Ressources */,::end::
 				4257533F1A5EFD8C004AA45B /* Images.xcassets in Resources */,
 				::ADDL_PBX_RESOURCES_BUILD_PHASE::
 			);
@@ -332,6 +336,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				::if (IOS_ADAPTIVE_ICON != null)::ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;::end::
 				::if (IOS_LAUNCH_STORYBOARD == null)::ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;::end::
 				CODE_SIGN_ENTITLEMENTS = "::APP_FILE::/::APP_FILE::.entitlements";
 				::if DEVELOPMENT_TEAM_ID::DEVELOPMENT_TEAM = ::DEVELOPMENT_TEAM_ID::;::end::
@@ -388,6 +393,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				::if (IOS_ADAPTIVE_ICON != null)::ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;::end::
 				::if (IOS_LAUNCH_STORYBOARD == null)::ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;::end::
 				CODE_SIGN_ENTITLEMENTS = "::APP_FILE::/::APP_FILE::.entitlements";
 				::if DEVELOPMENT_TEAM_ID::DEVELOPMENT_TEAM = ::DEVELOPMENT_TEAM_ID::;::end::

--- a/templates/mac/Info.plist
+++ b/templates/mac/Info.plist
@@ -8,6 +8,8 @@
 	<string>::APP_FILE::</string>
 	<key>CFBundleIconFile</key>
 	<string>icon.icns</string>
+	<key>CFBundleIconName</key>
+	<string>icon</string>
 	<key>CFBundleIdentifier</key>
 	<string>::APP_PACKAGE::</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/tools/platforms/IOSPlatform.hx
+++ b/tools/platforms/IOSPlatform.hx
@@ -540,6 +540,11 @@ class IOSPlatform extends PlatformTarget
 
 		context.HAS_ICON = true;
 
+		if (project.adaptiveIcon != null && project.adaptiveIcon.iconComposerFile) {
+			context.IOS_ADAPTIVE_ICON = project.adaptiveIcon.path;
+			ProjectHelper.recursiveSmartCopyDirectory(project, project.adaptiveIcon.path, Path.combine(projectDirectory, "AppIcon.icon"), context);
+		}
+
 		var iconPath = Path.combine(projectDirectory, "Images.xcassets/AppIcon.appiconset");
 		System.mkdir(iconPath);
 

--- a/tools/platforms/MacPlatform.hx
+++ b/tools/platforms/MacPlatform.hx
@@ -447,6 +447,11 @@ class MacPlatform extends PlatformTarget
 		context.HAS_ICON = IconHelper.createMacIcon(icons, Path.combine(contentDirectory, "icon.icns"));
 
 		copyProjectAssets(targetDirectory, contentDirectory);
+
+		if (project.adaptiveIcon != null && project.adaptiveIcon.iconComposerFile) {
+			context.MACOS_ADAPTIVE_ICON = project.adaptiveIcon.path;
+			ProjectHelper.recursiveSmartCopyDirectory(project, project.adaptiveIcon.path, Path.combine(contentDirectory, "icon.icon"), context);
+		}
 	}
 
 	public override function install():Void {}


### PR DESCRIPTION
This pull requests adds the ability to use `.icon` files for adaptive app icons

These files are generated via [Icon Composer](https://developer.apple.com/icon-composer/) which is only available on macOS

Note: this doesn’t apply the icon on iOS 18, macOS 15 and older as it is a iOS and macOS 26 and newer exclusive format, so older version need to have legacy icon formats added