### PR TITLE
[FEATURE/linux] Add Wayland support

### DIFF
--- a/project/lib/custom/sdl/include/SDL_build_config.h
+++ b/project/lib/custom/sdl/include/SDL_build_config.h
@@ -551,6 +551,18 @@
 /** @} */
 
 /**
+ * @name Wayland Video Driver
+ * @brief Wayland Window System video driver with extensions.
+ * @{
+ */
+# define SDL_VIDEO_DRIVER_WAYLAND 1                                         /**< Wayland video driver */
+# define SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC "libwayland-client.so.0"          /**< Wayland client library */
+# define SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_CURSOR "libwayland-cursor.so.0"   /**< Wayland cursor library */
+# define SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_EGL "libwayland-egl.so.1"         /**< Wayland EGL library */
+# define SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR "libdecor-0.so.0"        /**< Wayland client-side decorations library */
+# define SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_XKBCOMMON "libxkbcommon.so.0"     /**< Wayland keymap library */
+
+/**
  * @name X11 Video Driver
  * @brief X Window System video driver with extensions.
  * @{

--- a/project/lib/sdl-files.xml
+++ b/project/lib/sdl-files.xml
@@ -536,6 +536,50 @@
             </section>
 
             <section if="linux">
+                <compilerflag value="-Iobj/generated/wayland" if="linux" />
+
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandclipboard.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandcolor.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylanddatamanager.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylanddyn.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandevents.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandkeyboard.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandmessagebox.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandmouse.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandopengles.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandshmbuffer.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandvideo.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandvulkan.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandwindow.c" />
+
+                <file name="obj/generated/wayland/alpha-modifier-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/color-management-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/cursor-shape-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/fractional-scale-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/frog-color-management-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/idle-inhibit-unstable-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/input-timestamps-unstable-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/keyboard-shortcuts-inhibit-unstable-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/pointer-constraints-unstable-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/pointer-gestures-unstable-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/pointer-warp-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/primary-selection-unstable-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/relative-pointer-unstable-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/single-pixel-buffer-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/tablet-v2-client-protocol.c" />
+                <file name="obj/generated/wayland/text-input-unstable-v3-client-protocol.c" />
+                <file name="obj/generated/wayland/viewporter-client-protocol.c" />
+                <file name="obj/generated/wayland/wayland-client-protocol.c" />
+                <file name="obj/generated/wayland/xdg-activation-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/xdg-decoration-unstable-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/xdg-dialog-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/xdg-foreign-unstable-v2-client-protocol.c" />
+                <file name="obj/generated/wayland/xdg-output-unstable-v1-client-protocol.c" />
+                <file name="obj/generated/wayland/xdg-shell-client-protocol.c" />
+                <file name="obj/generated/wayland/xdg-toplevel-icon-v1-client-protocol.c" />
+            </section>
+
+            <section if="linux">
                 <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/x11/edid-parse.c" />
                 <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/x11/SDL_x11clipboard.c" />
                 <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/x11/SDL_x11dyn.c" />

--- a/tools/platforms/LinuxPlatform.hx
+++ b/tools/platforms/LinuxPlatform.hx
@@ -465,8 +465,38 @@ class LinuxPlatform extends PlatformTarget
 		}
 	}
 
+	/**
+	 * Generates the Wayland Protocols into the project obj folder before rebuild.
+	 */
+	private function generateWaylandProtocols():Void
+	{
+		Log.println("Generating Wayland Protocols");
+		var outputDir = project.config.get("project.rebuild.path") + "/obj/generated/wayland";
+		var sdlPath = project.config.get("project.rebuild.path") + "/lib/sdl/wayland-protocols";
+
+		if (!FileSystem.exists(outputDir)) FileSystem.createDirectory(outputDir);
+
+		if (FileSystem.exists(sdlPath))
+		{
+			var xmls:Array<String> = FileSystem.readDirectory(sdlPath);
+			for (xml in xmls)
+			{
+				if (!StringTools.endsWith(xml, ".xml")) continue;
+
+				var name = xml.substring(0, xml.lastIndexOf("."));
+				var xmlPath = '$sdlPath/$xml';
+
+				Log.println(' - obj/generated/wayland/$xml');
+				System.runCommand("", "wayland-scanner", ["client-header", xmlPath, '$outputDir/$name-client-protocol.h']);
+				System.runCommand("", "wayland-scanner", ["private-code", xmlPath, '$outputDir/$name-client-protocol.c']);
+			}
+		}
+	}
+
 	public override function rebuild():Void
 	{
+		generateWaylandProtocols();
+
 		var commands = [];
 
 		if (System.hostArchitecture == ARM64 )


### PR DESCRIPTION
## Description
This PR adds support for Wayland on lime. And some fixes for compiling on linux.

> [!IMPORTANT]
> For the Window Alert/Message Box to appear under wayland (instead of X11), users have to install [zenity](https://github.com/GNOME/zenity) because of this [sdl/SDL_waylandmessagebox.c#L39](https://github.com/libsdl-org/SDL/blob/2aacf018f0aa454177d774240eb34f064d8f36cb/src/video/wayland/SDL_waylandmessagebox.c#L39)