### PR TITLE
Fix conflicts with MSVC defines on HL/C

### DIFF
--- a/src/lime/tools/HashlinkHelper.hx
+++ b/src/lime/tools/HashlinkHelper.hx
@@ -123,6 +123,10 @@ class HashlinkHelper
 			appMainCText = appMainCText.substr(0, index) + "
 // --------- START LIME HL/C INJECTED CODE --------- //
 // undefine things to avoid Haxe field name conflicts
+#undef String
+#undef small
+#undef EFAULT
+#undef EINVAL
 #undef BIG_ENDIAN
 #undef LITTLE_ENDIAN
 #undef TRUE


### PR DESCRIPTION
Fixes conflicts with defines set by Windows SDK files when compiling to HashLink/C.

> [!NOTE]
> Requires a `tools` rebuild to take effect but I don't know if these are allowed to include. 