### PR TITLE
Add `lime-funkin`/`lime_funkin` define

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -10,6 +10,7 @@
 	<define name="native" if="cpp || hl" />
 	<define name="howlerjs" if="html5" />
 
+	<define name="lime-funkin" />
 	<define name="lime-cairo" if="native" />
 	<define name="lime-canvas" if="html5" />
 	<define name="lime-cffi" if="native" />

--- a/src/lime/_internal/macros/DefineMacro.hx
+++ b/src/lime/_internal/macros/DefineMacro.hx
@@ -10,6 +10,8 @@ class DefineMacro
 	{
 		if (!Context.defined("tools"))
 		{
+			Compiler.define("lime-funkin");
+
 			if (Context.defined("js"))
 			{
 				Compiler.define("html5");


### PR DESCRIPTION
Because of the different implementations will be from the upstream lime, this is really needed for libraries that uses implementations that are not in lime_funkin or upstream lime.