### PR TITLE
Update OpenAL-Soft, & use SDL3 as an audio backend if compiled with SDL3

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -34,11 +34,8 @@ public domain. For details, see [project/lib/lzma/](project/lzma).
 This product bundles mbedTLS 2.6.0, which is available under an
 "Apache 2.0" license. For details, see [project/lib/mbedtls/](project/lib).
 
-This product bundles OpenAL-Soft 1.19.0, which is available under an
+This product bundles OpenAL-Soft 1.25.1, which is available under an
 "LGPLv2" license. For details, see [project/lib/openal/](project/lib).
-
-_OpenAL-Soft is only included in dynamically-linked builds, it is excluded
-from Lime static builds in order to preserve Lime's permissive nature._
 
 This product bundles pixman 0.32.8, which is available under an
 "MIT" license. For details, see [project/lib/pixman/](project/lib).

--- a/project/lib/custom/openal/include/platforms/android/config_backends.h
+++ b/project/lib/custom/openal/include/platforms/android/config_backends.h
@@ -1,3 +1,13 @@
+#ifdef NATIVE_TOOLKIT_HAVE_SDL
+
+#define HAVE_OPENSL 0
+
+#else
+
+#define HAVE_OPENSL 1
+
+#endif
+
 #define HAVE_ALSA 0
 
 #define HAVE_OSS 0
@@ -21,7 +31,5 @@
 #define HAVE_JACK 0
 
 #define HAVE_COREAUDIO 0
-
-#define HAVE_OPENSL 1
 
 #define HAVE_OBOE 0

--- a/project/lib/custom/openal/include/platforms/apple/config_backends.h
+++ b/project/lib/custom/openal/include/platforms/apple/config_backends.h
@@ -1,3 +1,13 @@
+#ifdef NATIVE_TOOLKIT_HAVE_SDL
+
+#define HAVE_COREAUDIO 0
+
+#else
+
+#define HAVE_COREAUDIO 1
+
+#endif
+
 #define HAVE_ALSA 0
 
 #define HAVE_OSS 0
@@ -19,8 +29,6 @@
 #define HAVE_PULSEAUDIO 0
 
 #define HAVE_JACK 0
-
-#define HAVE_COREAUDIO 1
 
 #define HAVE_OPENSL 0
 

--- a/project/lib/custom/openal/include/platforms/linux/config_backends.h
+++ b/project/lib/custom/openal/include/platforms/linux/config_backends.h
@@ -1,8 +1,22 @@
+#ifdef NATIVE_TOOLKIT_HAVE_SDL
+
+#define HAVE_ALSA 0
+
+#define HAVE_PIPEWIRE 0
+
+#define HAVE_PULSEAUDIO 0
+
+#else
+
 #define HAVE_ALSA 1
 
-#define HAVE_OSS 0
-
 #define HAVE_PIPEWIRE 1
+
+#define HAVE_PULSEAUDIO 1
+
+#endif
+
+#define HAVE_OSS 0
 
 #define HAVE_SOLARIS 0
 
@@ -15,8 +29,6 @@
 #define HAVE_WINMM 0
 
 #define HAVE_PORTAUDIO 0
-
-#define HAVE_PULSEAUDIO 1
 
 #define HAVE_JACK 0
 

--- a/project/lib/custom/openal/include/platforms/windows/config_backends.h
+++ b/project/lib/custom/openal/include/platforms/windows/config_backends.h
@@ -1,3 +1,17 @@
+#ifdef NATIVE_TOOLKIT_HAVE_SDL
+
+#define HAVE_WASAPI 0
+
+#define HAVE_DSOUND 0
+
+#else
+
+#define HAVE_WASAPI 1
+
+#define HAVE_DSOUND 1
+
+#endif
+
 #define HAVE_ALSA 0
 
 #define HAVE_OSS 0
@@ -7,10 +21,6 @@
 #define HAVE_SOLARIS 0
 
 #define HAVE_SNDIO 0
-
-#define HAVE_WASAPI 1
-
-#define HAVE_DSOUND 1
 
 #define HAVE_WINMM 0
 

--- a/project/lib/custom/openal/include/version.h
+++ b/project/lib/custom/openal/include/version.h
@@ -6,4 +6,4 @@
 #define ALSOFT_GIT_BRANCH "master"
 
 /* Define the hash of the head commit */
-#define ALSOFT_GIT_COMMIT_HASH "1d52120"
+#define ALSOFT_GIT_COMMIT_HASH "0887e589"

--- a/project/lib/openal-files.xml
+++ b/project/lib/openal-files.xml
@@ -131,13 +131,15 @@
 
             <section>
 
-                <section>
+                <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/null.cpp" />
+                <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/base.cpp" />
+                <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/loopback.cpp" />
 
-                    <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/base.cpp" />
-                    <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/loopback.cpp" />
-                    <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/null.cpp" />
+            </section>
 
-                </section>
+            <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/sdl3.cpp" if="NATIVE_TOOLKIT_HAVE_SDL" />
+
+            <section unless="NATIVE_TOOLKIT_HAVE_SDL" >
 
                 <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/opensl.cpp" if="android" />
 
@@ -157,8 +159,6 @@
                     <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/wasapi.cpp" />
 
                 </section>
-
-                <file name="${NATIVE_TOOLKIT_PATH}/openal/alc/backends/sdl3.cpp" if="NATIVE_TOOLKIT_HAVE_SDL" />
 
             </section>
 
@@ -201,6 +201,7 @@
             <file name="${NATIVE_TOOLKIT_PATH}/openal/common/almalloc.cpp" />
             <file name="${NATIVE_TOOLKIT_PATH}/openal/common/alstring.cpp" />
             <file name="${NATIVE_TOOLKIT_PATH}/openal/common/althrd_setname.cpp" />
+            <file name="${NATIVE_TOOLKIT_PATH}/openal/common/altypes.cpp" />
             <file name="${NATIVE_TOOLKIT_PATH}/openal/common/dynload.cpp" />
             <file name="${NATIVE_TOOLKIT_PATH}/openal/common/filesystem.cpp" />
             <file name="${NATIVE_TOOLKIT_PATH}/openal/common/pffft.cpp" />

--- a/src/lime/media/AudioManager.hx
+++ b/src/lime/media/AudioManager.hx
@@ -54,15 +54,10 @@ class AudioManager
 						alc.makeContextCurrent(ctx);
 						alc.processContext(ctx);
 
-						#if (lime_openalsoft && !mobile)
-						if (alc.isExtensionPresent('ALC_SOFT_system_events', device) && alc.isExtensionPresent('ALC_SOFT_reopen_device', device))
+						#if (lime_openalsoft)
+						if (alc.isExtensionPresent('AL_SOFT_hold_on_disconnect'))
 						{
-							if (alc.isExtensionPresent('AL_SOFT_hold_on_disconnect'))
-								alc.disable(AL.STOP_SOURCES_ON_DISCONNECT_SOFT);
-
-							alc.eventControlSOFT([ALC.EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT, ALC.EVENT_TYPE_DEVICE_ADDED_SOFT, ALC.EVENT_TYPE_DEVICE_REMOVED_SOFT], true);
-
-							alc.eventCallbackSOFT(deviceEventCallback);
+							alc.disable(AL.STOP_SOURCES_ON_DISCONNECT_SOFT);
 						}
 						#end
 					}
@@ -138,39 +133,6 @@ class AudioManager
 		}
 		#end
 	}
-
-	#if lime_openalsoft
-	@:noCompletion
-	private static function deviceEventCallback(eventType:Int, deviceType:Int, handle:CFFIPointer, message:#if hl hl.Bytes #else String #end):Void
-	{
-		#if !lime_doc_gen
-		if (eventType == ALC.EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT && deviceType == ALC.PLAYBACK_DEVICE_SOFT)
-		{
-			var device = new ALDevice(handle);
-
-			MainLoop.runInMainThread(function():Void
-			{
-				var alc = context.openal;
-
-				if (device == null)
-				{
-					var currentContext = alc.getCurrentContext();
-
-					var device = alc.getContextsDevice(currentContext);
-
-					if (device != null)
-						alc.reopenDeviceSOFT(device, null, null);
-				}
-				else
-				{
-					alc.reopenDeviceSOFT(device, null, null);
-				}
-
-			});
-		}
-		#end
-	}
-	#end
 
 	@:noCompletion
 	private static function setupConfig():Void


### PR DESCRIPTION
Update OpenAL-Soft to fix the issues with SDL3 not having capturing implemented, and device events not supported (except default device is still isnt supported, but maybe that'll be changed later).
- https://github.com/kcat/openal-soft/issues/1266

Reason with using SDL3 is that there is no duplicated codes of an audio backend because in funkin-lime cases, it already have that in SDL3,

...and to minimize the added latency for whatever reason in OpenAL-Soft Wasapi (Windows)