### PR TITLE
Add missing `AL` enums, & functions

### DIFF
--- a/src/lime/_internal/backend/native/NativeCFFI.hx
+++ b/src/lime/_internal/backend/native/NativeCFFI.hx
@@ -1563,6 +1563,12 @@ class NativeCFFI
 
 	@:cffi private static function lime_al_delete_sources(n:Int, sources:Dynamic):Void;
 
+	@:cffi private static function lime_al_delete_effect(buffer:CFFIPointer):Void;
+
+	@:cffi private static function lime_al_delete_filter(buffer:CFFIPointer):Void;
+
+	@:cffi private static function lime_al_delete_auxiliary_effect_slot(slot:CFFIPointer):Void;
+
 	@:cffi private static function lime_al_disable(capability:Int):Void;
 
 	@:cffi private static function lime_al_distance_model(distanceModel:Int):Void;
@@ -1802,6 +1808,10 @@ class NativeCFFI
 	private static var lime_al_delete_source = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_delete_source", "ov", false));
 	private static var lime_al_delete_sources = new cpp.Callable<Int->cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_delete_sources", "iov",
 		false));
+	private static var lime_al_delete_effect = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_delete_effect", "ov", false));
+	private static var lime_al_delete_filter = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_delete_filter", "ov", false));
+	private static var lime_al_delete_auxiliary_effect_slot = new cpp.Callable<cpp.Object->cpp.Void>(cpp.Prime._loadPrime("lime",
+		"lime_al_delete_auxiliary_effect_slot", "ov", false));
 	private static var lime_al_disable = new cpp.Callable<Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_disable", "iv", false));
 	private static var lime_al_distance_model = new cpp.Callable<Int->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_distance_model", "iv", false));
 	private static var lime_al_doppler_factor = new cpp.Callable<cpp.Float32->cpp.Void>(cpp.Prime._loadPrime("lime", "lime_al_doppler_factor", "fv", false));
@@ -1971,6 +1981,9 @@ class NativeCFFI
 	private static var lime_al_delete_buffers = CFFI.load("lime", "lime_al_delete_buffers", 2);
 	private static var lime_al_delete_source = CFFI.load("lime", "lime_al_delete_source", 1);
 	private static var lime_al_delete_sources = CFFI.load("lime", "lime_al_delete_sources", 2);
+	private static var lime_al_delete_effect = CFFI.load("lime", "lime_al_delete_effect", 1);
+	private static var lime_al_delete_filter = CFFI.load("lime", "lime_al_delete_filter", 1);
+	private static var lime_al_delete_auxiliary_effect_slot = CFFI.load("lime", "lime_al_delete_auxiliary_effect_slot", 1);
 	private static var lime_al_disable = CFFI.load("lime", "lime_al_disable", 1);
 	private static var lime_al_distance_model = CFFI.load("lime", "lime_al_distance_model", 1);
 	private static var lime_al_doppler_factor = CFFI.load("lime", "lime_al_doppler_factor", 1);
@@ -2107,6 +2120,12 @@ class NativeCFFI
 	@:hlNative("lime", "hl_al_delete_source") private static function lime_al_delete_source(source:CFFIPointer):Void {}
 
 	@:hlNative("lime", "hl_al_delete_sources") private static function lime_al_delete_sources(n:Int, sources:hl.NativeArray<CFFIPointer>):Void {}
+
+	@:hlNative("lime", "hl_al_delete_effect") private static function lime_al_delete_effect(buffer:CFFIPointer):Void {}
+
+	@:hlNative("lime", "hl_al_delete_filter") private static function lime_al_delete_filter(buffer:CFFIPointer):Void {}
+
+	@:hlNative("lime", "hl_al_delete_auxiliary_effect_slot") private static function lime_al_delete_auxiliary_effect_slot(slot:CFFIPointer):Void {}
 
 	@:hlNative("lime", "hl_al_disable") private static function lime_al_disable(capability:Int):Void {}
 

--- a/src/lime/media/openal/AL.hx
+++ b/src/lime/media/openal/AL.hx
@@ -233,15 +233,47 @@ class AL
 	public static inline var FILTER_LOWPASS:Int = 0x0001;
 	public static inline var FILTER_HIGHPASS:Int = 0x0002;
 	public static inline var FILTER_BANDPASS:Int = 0x0003;
+	/* AL_EXT_float32 */
+	public static inline var FORMAT_MONO_FLOAT32:Int = 0x10010;
+	public static inline var FORMAT_STEREO_FLOAT32:Int = 0x10011;
+	/* UNKNOWN */
+	public static inline var FORMAT_MONO32:Int = 0x1202;
+	public static inline var FORMAT_STEREO32:Int = 0x1203;
+	/* AL_EXT_MCFORMATS */
+	public static inline var FORMAT_QUAD8:Int = 0x1204;
+	public static inline var FORMAT_QUAD16:Int = 0x1205;
+	public static inline var FORMAT_QUAD32:Int = 0x1206;
+	public static inline var FORMAT_REAR8:Int = 0x1207;
+	public static inline var FORMAT_REAR16:Int = 0x1208;
+	public static inline var FORMAT_REAR32:Int = 0x1209;
+	public static inline var FORMAT_51CHN8:Int = 0x120A;
+	public static inline var FORMAT_51CHN16:Int = 0x120B;
+	public static inline var FORMAT_51CHN32:Int = 0x120C;
+	public static inline var FORMAT_61CHN8:Int = 0x120D;
+	public static inline var FORMAT_61CHN16:Int = 0x120E;
+	public static inline var FORMAT_61CHN32:Int = 0x120F;
+	public static inline var FORMAT_71CHN8:Int = 0x1210;
+	public static inline var FORMAT_71CHN16:Int = 0x1211;
+	public static inline var FORMAT_71CHN32:Int = 0x1212;
 	#if lime_openalsoft
 	/* AL_SOFT_direct_channels extension */
 	public static inline var DIRECT_CHANNELS_SOFT:Int = 0x1033;
 	/* AL_SOFT_direct_channels_remix extension */
 	public static inline var DROP_UNMATCHED_SOFT:Int = 0x0001;
 	public static inline var REMIX_UNMATCHED_SOFT:Int = 0x0002;
-	/* AL_SOFT_source_latency extension */
-	public static inline var SAMPLE_OFFSET_LATENCY_SOFT = 0x1200;
-	public static inline var SEC_OFFSET_LATENCY_SOFT = 0x1201;
+	/* AL_SOFT_loop_points */
+	public static inline var LOOP_POINTS_SOFT:Int = 0x2015;
+	/* AL_EXT_STEREO_ANGLES */
+	public static inline var STEREO_ANGLES:Int = 0x1030;
+	/* AL_SOFT_source_latency */
+	public static inline var SAMPLE_OFFSET_LATENCY_SOFT:Int = 0x1200;
+	public static inline var SEC_OFFSET_LATENCY_SOFT:Int = 0x1201;
+	/* AL_SOFT_source_spatialize */
+	public static inline var SOURCE_SPATIALIZE_SOFT:Int = 0x1214;
+	public static inline var AUTO_SOFT:Int = 0x0002;
+	/* ALC_SOFT_device_clock */
+	public static inline var SAMPLE_OFFSET_CLOCK_SOFT:Int = 0x1202;
+	public static inline var SEC_OFFSET_CLOCK_SOFT:Int = 0x1203;
 	/* AL_SOFT_hold_on_disconnect */
 	public static inline var STOP_SOURCES_ON_DISCONNECT_SOFT:Int = 0x19AB;
 	#end
@@ -443,6 +475,27 @@ class AL
 		var sources = _sources;
 		#end
 		NativeCFFI.lime_al_delete_sources(sources.length, sources);
+		#end
+	}
+
+	public static function deleteEffect(effect:ALEffect):Void
+	{
+		#if (lime_cffi && lime_openal && !macro)
+		NativeCFFI.lime_al_delete_effect(effect);
+		#end
+	}
+
+	public static function deleteFilter(filter:ALFilter):Void
+	{
+		#if (lime_cffi && lime_openal && !macro)
+		NativeCFFI.lime_al_delete_filter(filter);
+		#end
+	}
+
+	public static function deleteAux(aux:ALAuxiliaryEffectSlot):Void
+	{
+		#if (lime_cffi && lime_openal && !macro)
+		NativeCFFI.lime_al_delete_auxiliary_effect_slot(aux);
 		#end
 	}
 

--- a/src/lime/media/openal/ALC.hx
+++ b/src/lime/media/openal/ALC.hx
@@ -26,18 +26,28 @@ class ALC
 	public static inline var INVALID_ENUM:Int = 0xA003;
 	public static inline var INVALID_VALUE:Int = 0xA004;
 	public static inline var OUT_OF_MEMORY:Int = 0xA005;
+	public static inline var MAJOR_VERSION:Int = 0x1000;
+	public static inline var MINOR_VERSION:Int = 0x1001;
 	public static inline var ATTRIBUTES_SIZE:Int = 0x1002;
 	public static inline var ALL_ATTRIBUTES:Int = 0x1003;
+	/* ALC_ENUMERATION_EXT */
 	public static inline var DEFAULT_DEVICE_SPECIFIER:Int = 0x1004;
 	public static inline var DEVICE_SPECIFIER:Int = 0x1005;
 	public static inline var EXTENSIONS:Int = 0x1006;
-	public static inline var ENUMERATE_ALL_EXT:Int = 1;
-	public static inline var DEFAULT_ALL_DEVICES_SPECIFIER:Int = 0x1012;
-	public static inline var ALL_DEVICES_SPECIFIER:Int = 0x1013;
+	/* ALC_EXT_CAPTURE */
 	public static inline var CAPTURE_DEVICE_SPECIFIER:Int = 0x310;
 	public static inline var CAPTURE_DEFAULT_DEVICE_SPECIFIER:Int = 0x311;
 	public static inline var CAPTURE_SAMPLES:Int = 0x312;
+	/* ALC_ENUMERATE_ALL_EXT */
+	public static inline var DEFAULT_ALL_DEVICES_SPECIFIER:Int = 0x1012;
+	public static inline var ALL_DEVICES_SPECIFIER:Int = 0x1013;
+	/* ALC_EXT_disconnect */
+	public static inline var CONNECTED:Int = 0x313;
 	#if lime_openalsoft
+	/* ALC_SOFT_device_clock */
+	public static inline var DEVICE_CLOCK_SOFT:Int = 0x1600;
+	public static inline var DEVICE_LATENCY_SOFT:Int = 0x1601;
+	public static inline var DEVICE_CLOCK_LATENCY_SOFT:Int = 0x1602;
 	/* ALC_SOFT_system_events */
 	public static inline var PLAYBACK_DEVICE_SOFT:Int = 0x19D4;
 	public static inline var CAPTURE_DEVICE_SOFT:Int = 0x19D5;
@@ -46,10 +56,6 @@ class ALC
 	public static inline var EVENT_TYPE_DEVICE_REMOVED_SOFT:Int = 0x19D8;
 	public static inline var EVENT_SUPPORTED_SOFT:Int = 0x19D9;
 	public static inline var EVENT_NOT_SUPPORTED_SOFT:Int = 0x19DA;
-	/* ALC_SOFT_device_clock */
-	public static inline var DEVICE_CLOCK_SOFT:Int = 0x1600;
-	public static inline var DEVICE_LATENCY_SOFT:Int = 0x1601;
-	public static inline var DEVICE_CLOCK_LATENCY_SOFT:Int = 0x1602;
 	#end
 
 	public static function closeDevice(device:ALDevice):Bool


### PR DESCRIPTION
Adds:
- functions: `AL.deleteEffect`, `AL.deleteFilter`, `AL.deleteAux`
- enums: `AL_EXT_float32`, `AL_EXT_MCFORMATS`, `AL_SOFT_loop_points`, `AL_EXT_STEREO_ANGLES`, `AL_SOFT_source_spatialize`, `ALC_SOFT_device_clock`, `ALC_ENUMERATION_EXT`, `ALC_EXT_CAPTURE`, `ALC_ENUMERATE_ALL_EXT`, `ALC_EXT_disconnect`, `FORMAT_MONO32` (undocumented), `FORMAT_STEREO32` (undocumented)