### PR TITLE
Fix `Bytes` segfault on HashLink

### DIFF
--- a/project/src/utils/Bytes.cpp
+++ b/project/src/utils/Bytes.cpp
@@ -16,6 +16,7 @@ namespace lime {
 
 	inline void _initializeBytes () {
 
+		#ifndef LIME_HASHLINK
 		if (!init) {
 
 			buffer _buffer = alloc_buffer_len (1);
@@ -29,6 +30,7 @@ namespace lime {
 			init = true;
 
 		}
+		#endif
 
 	}
 


### PR DESCRIPTION
https://github.com/FunkinCrew/lime/commit/b08c53ea992a050d1caa368c7219e908015fd3dc causes the initialization of `Bytes`, which references HXCPP components, causing a segfault. We avoid this code from running on the HDLLs to fix it.