### PR TITLE
Remove resize handling on `Linux` as it doesn't need it

### DIFF
--- a/project/src/backend/sdl/SDLApplication.cpp
+++ b/project/src/backend/sdl/SDLApplication.cpp
@@ -66,7 +66,7 @@ namespace lime {
 
 		SDL_SetEventFilter (HandleAppLifecycleEvent, NULL);
 
-		#if defined(HX_WINDOWS) || defined(HX_MACOS) || defined(HX_LINUX)
+		#if defined(HX_WINDOWS) || defined(HX_MACOS)
 		SDL_AddEventWatch (HandleEventWatcher, NULL);
 		#endif
 
@@ -893,7 +893,7 @@ namespace lime {
 	}
 
 
-	#if defined(HX_WINDOWS) || defined(HX_MACOS) || defined(HX_LINUX)
+	#if defined(HX_WINDOWS) || defined(HX_MACOS)
 	bool SDLApplication::HandleEventWatcher (void *userdata, SDL_Event *event) {
 
 		if (!inBackground) {


### PR DESCRIPTION
Linux already seems to handle window events asynchronously