### PR TITLE
Properly check if audio is completed

### DIFF
--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -215,16 +215,12 @@ class NativeAudioSource
 
 		if (playing)
 		{
-			var timeRemaining = Std.int((getLength() - value) / getPitch());
+			completed = false;
 
-			if (timeRemaining > 0)
+			if (value >= getLength())
 			{
-				completed = false;
-			}
-			else
-			{
-				playing = false;
 				completed = true;
+				playing = false;
 			}
 		}
 


### PR DESCRIPTION
Goes well with FunkinCrew/Funkin#7614

I guess audio doesn't do a good enough job at determining if it's completed.