### PR TITLE
Fix `Linux` build issues resulting from update to SDL

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -431,6 +431,7 @@
 
 				<lib name="-lpthread" />
 				<lib name="-lrt" />
+				<lib name='-ludev' />
 
 				<section if="LIME_HASHLINK">
 

--- a/project/lib/sdl-files.xml
+++ b/project/lib/sdl-files.xml
@@ -135,6 +135,7 @@
                 <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/core/linux/SDL_system_theme.c" />
                 <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/core/linux/SDL_threadprio.c" />
                 <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/core/linux/SDL_udev.c" />
+                <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/core/linux/SDL_ubuntu_touch.c" />
 
             </section>
 
@@ -655,6 +656,7 @@
                     <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylanddatamanager.c" />
                     <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylanddyn.c" />
                     <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandevents.c" />
+                    <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandeventthread.c" />
                     <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandkeyboard.c" />
                     <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandmessagebox.c" />
                     <file name="${NATIVE_TOOLKIT_PATH}/sdl/src/video/wayland/SDL_waylandmouse.c" />

--- a/project/lib/wayland-protocols-files.xml
+++ b/project/lib/wayland-protocols-files.xml
@@ -27,10 +27,10 @@
 			<file name="${NATIVE_TOOLKIT_PATH}/sdl/wayland-generated-protocols/xdg-dialog-v1-client-protocol.c" />
 			<file name="${NATIVE_TOOLKIT_PATH}/sdl/wayland-generated-protocols/xdg-foreign-unstable-v2-client-protocol.c" />
 			<file name="${NATIVE_TOOLKIT_PATH}/sdl/wayland-generated-protocols/xdg-output-unstable-v1-client-protocol.c" />
-			<file name="${NATIVE_TOOLKIT_PATH}/sdl/wayland-generated-protocols/xdg-session-management-v1.c" />
+			<file name="${NATIVE_TOOLKIT_PATH}/sdl/wayland-generated-protocols/xdg-session-management-v1-client-protocol.c" />
 			<file name="${NATIVE_TOOLKIT_PATH}/sdl/wayland-generated-protocols/xdg-shell-client-protocol.c" />
 			<file name="${NATIVE_TOOLKIT_PATH}/sdl/wayland-generated-protocols/xdg-toplevel-icon-v1-client-protocol.c" />
-			<file name="${NATIVE_TOOLKIT_PATH}/sdl/wayland-generated-protocols/xdg-toplevel-tag-v1.c" />
+			<file name="${NATIVE_TOOLKIT_PATH}/sdl/wayland-generated-protocols/xdg-toplevel-tag-v1-client-protocol.c" />
 		</section>
 	</files>
 


### PR DESCRIPTION
Addresses some missing file inclusions, wrong file names, and missing link flag