### PR TITLE
typos fixes and alot of other things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changelog
 - Added verbose log message when rebuilding a Haxelib's tools to show the name of the Haxelib.
 - Added warning log message when rebuilding a Haxelib's tools when no rebuild script is found.
 - Added warning log message when `<architecture/>` value is unrecognized.
-- Added error when attemping to rebuild HashLink for ARM64.
+- Added error when attempting to rebuild HashLink for ARM64.
 - Added internal exception message to error reported when NDLL loading fails.
 - Fixed exception on some targets in `AudioBuffer` when trying to read codec signature string from bytes.
 - Fixed `length` value of `Bytes` on HTML5 target when using `Bytes.fromBytes()`.

--- a/src/haxe/Timer.hx
+++ b/src/haxe/Timer.hx
@@ -195,7 +195,7 @@ class Timer
 	}
 }
 #else
-// This override mainly exists so targets like iOS wont be freezing because of the way the mainloop works on the target
+// This override mainly exists so targets like iOS won't be freezing because of the way the mainloop works on the target
 import lime.system.System;
 
 class Timer

--- a/src/lime/_internal/backend/html5/HTML5Application.hx
+++ b/src/lime/_internal/backend/html5/HTML5Application.hx
@@ -245,7 +245,7 @@ class HTML5Application
 				var observer = new IntersectionObserver(function(entries) {
 					var visible = entries[0].isIntersecting;
 
-					// idk if js has a event for what i want but that works for now
+					// idk if js has an event for what i want but that works for now
 					var event = new CustomEvent('canvasVisibilityChange', {
 						detail: { visible: visible }
 					});

--- a/src/lime/net/URIParser.hx
+++ b/src/lime/net/URIParser.hx
@@ -105,7 +105,7 @@ class URIParser
 	/**
 		The "#hash" part of the URI.
 		In `"https://example.com/index.php?action=upload&token=12345#header"` this would be `"header"`.
-		In a more sophisicated example `"https://example.com/index.php?action=upload#header=/abc/1234"`
+		In a more sophisticated example `"https://example.com/index.php?action=upload#header=/abc/1234"`
 		that would be `"header=/abc/1234"`.
 		`null` if unspecified or malformed.
 	**/

--- a/src/lime/tools/XCodeHelper.hx
+++ b/src/lime/tools/XCodeHelper.hx
@@ -6,7 +6,7 @@ import lime.tools.HXProject;
 class XCodeHelper
 {
 	// different computers may have different sets of simulators installed
-	// so there isn't necessarily a reasonable default for ipads
+	// so there isn't necessarily a reasonable default for iPads
 	private static var DEFAULT_IPAD_SIMULATOR_NAMES = ["ipad", "ipad-air"];
 	private static var DEFAULT_IPAD_AIR_SIMULATOR_FALLBACK_REGEX = ~/ipad-air-.+/g;
 	private static var DEFAULT_IPAD_SIMULATOR_FALLBACK_REGEX = ~/ipad-.+/g;
@@ -100,7 +100,7 @@ class XCodeHelper
 			{
 				for (device in DEFAULT_IPAD_SIMULATOR_NAMES)
 				{
-					// try to find a relatively standard ipad simulator
+					// try to find a relatively standard iPad simulator
 					currentDevice = devices.get(device);
 					if (currentDevice != null)
 					{
@@ -121,7 +121,7 @@ class XCodeHelper
 					}
 				}
 				// worst case, if we still haven't found a good name, choose the
-				// first ipad that we find. it could be a mini or pro, which
+				// first iPad that we find. it could be a mini or pro, which
 				// might not necessarily be ideal, but it's better than nothing.
 				if (currentDevice == null)
 				{
@@ -139,7 +139,7 @@ class XCodeHelper
 			{
 				for (device in devices.keys())
 				{
-					// try to find a standard iphone, which should have an name
+					// try to find a standard iPhone, which should have a name
 					// like iphone-15 or iphone-16
 					if (DEFAULT_IPHONE_SIMULATOR_REGEX.match(device))
 					{
@@ -147,8 +147,8 @@ class XCodeHelper
 						break;
 					}
 				}
-				// of we can't find a standard iphone for some reason, choose
-				// the first iphone- name that we find. it could be a plus, pro,
+				// if we can't find a standard iPhone for some reason, choose
+				// the first iPhone- name that we find. it could be a plus, pro,
 				// se, or something that might not necessarily be ideal, but
 				// it's better than nothing at all.
 				if (currentDevice == null)

--- a/src/lime/utils/ArrayBufferView.hx
+++ b/src/lime/utils/ArrayBufferView.hx
@@ -751,7 +751,7 @@ class ArrayBufferView
 	}
 
 	// Internal
-	// clamp a Int to a 0-255 Uint8 (for Uint8Clamped array)
+	// clamp an Int to a 0-255 Uint8 (for Uint8Clamped array)
 	static inline extern function _clamp(_in:Float):Int
 	{
 		var _out = Std.int(_in);

--- a/src/lime/utils/UInt8ClampedArray.hx
+++ b/src/lime/utils/UInt8ClampedArray.hx
@@ -79,7 +79,7 @@ abstract UInt8ClampedArray(JSUInt8ClampedArray) from JSUInt8ClampedArray to JSUI
 		return this != null ? 'UInt8ClampedArray [byteLength:${this.byteLength}, length:${this.length}]' : null;
 
 	// internal
-	// clamp a Int to a 0-255 Uint8
+	// clamp an Int to a 0-255 Uint8
 	static function _clamp(_in:Float):Int
 	{
 		var _out = Std.int(_in);

--- a/tools/platforms/HTML5Platform.hx
+++ b/tools/platforms/HTML5Platform.hx
@@ -467,7 +467,7 @@ class HTML5Platform extends PlatformTarget
 			}
 		}
 
-		// For some reason it seems to crash in here if the shutdown runs, should be figured out later but it shoudnt cause any issues for now ig
+		// For some reason it seems to crash in here if the shutdown runs, should be figured out later but it shouldn't cause any issues for now ig
 		// Font.shutdown();
 
 		ProjectHelper.recursiveSmartCopyTemplate(project, "html5/template", destination, context);

--- a/tools/platforms/LinuxPlatform.hx
+++ b/tools/platforms/LinuxPlatform.hx
@@ -327,8 +327,8 @@ class LinuxPlatform extends PlatformTarget
 	{
 		if (project.haxelibs.length == 0)
 		{
-			// If there are no haxelibs, we know its only lime that is being rebuilt (weird hack but works),
-			// Wayland shoudnt be rebuilt for anything else other than lime!
+			// If there are no haxelibs, we know it's only lime that is being rebuilt (weird hack but works),
+			// Wayland shouldn't be rebuilt for anything else other than lime!
 			generateWaylandProtocols();
 		}
 

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -124,7 +124,7 @@ class WindowsPlatform extends PlatformTarget
 			haxeArgs.push("mingw");
 			flags.push("-Dmingw");
 
-			// For some reason `MinGW` uses the shared deps by default, which we dont really want do we?
+			// For some reason `MinGW` uses the shared deps by default, which we don't really want, do we?
 			haxeArgs.push("-D");
 			haxeArgs.push("no_shared_libs");
 			flags.push("-Dno_shared_libs");
@@ -241,7 +241,7 @@ class WindowsPlatform extends PlatformTarget
 			{
 				args.push("-Dmingw");
 
-				// For some reason `MinGW` uses the shared deps by default, which we dont really want do we?
+				// For some reason `MinGW` uses the shared deps by default, which we don't really want, do we?
 				args.push("-Dno_shared_libs");
 			}
 
@@ -256,7 +256,7 @@ class WindowsPlatform extends PlatformTarget
 			{
 				args.push("-Dmingw");
 
-				// For some reason `MinGW` uses the shared deps by default, which we dont really want do we?
+				// For some reason `MinGW` uses the shared deps by default, which we don't really want, do we?
 				args.push("-Dno_shared_libs");
 			}
 

--- a/tools/utils/PlatformSetup.hx
+++ b/tools/utils/PlatformSetup.hx
@@ -793,7 +793,7 @@ class PlatformSetup
 
 		if (hasApt)
 		{
-			// check if this is ubuntu saucy 64bit, which uses different packages.
+			// check if this is Ubuntu Saucy 64-bit, which uses different packages.
 			var lsbId = System.runProcess("", "lsb_release", ["-si"], true, true, true);
 			var lsbRelease = System.runProcess("", "lsb_release", ["-sr"], true, true, true);
 			var arch = System.runProcess("", "uname", ["-m"], true, true, true);


### PR DESCRIPTION
## Typos (6):
- URIParser.hx:108 — sophisicated → sophisticated
- LinuxPlatform.hx:489 — shoudnt → shouldn't
- HTML5Platform.hx:530 — shoudnt → shouldn't
- CHANGELOG.md:11 — attemping → attempting
- XCodeHelper.hx:150 — of we → if we
## Grammar (6):
- XCodeHelper.hx:142 — an name → a name
- ArrayBufferView.hx:754 — a Int → an Int
- UInt8ClampedArray.hx:82 — a Int → an Int
- HTML5Application.hx:248 — a event → an event
- LinuxPlatform.hx:488 — its only → it's only
- WindowsPlatform.hx:335,465,485 — added missing comma before do we?
## Casing (7):
- PlatformSetup.hx:800 — ubuntu saucy 64bit → Ubuntu Saucy 64-bit
- XCodeHelper.hx:9 — ipads → iPads
- XCodeHelper.hx:103 — ipad simulator → iPad simulator
- XCodeHelper.hx:124 — first ipad → first iPad
- XCodeHelper.hx:142 — iphone → iPhone
- XCodeHelper.hx:150 — iphone → iPhone
- XCodeHelper.hx:151 — iphone- → iPhone-
## Apostrophes (2):
- WindowsPlatform.hx:335,465,485 — dont → don't
- Timer.hx:210 — wont → won't