### PR TITLE
Remove HashLink from the workflows

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -26,11 +26,10 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
 
-      - name: Delete old NDLL's and Hashlink Templates
+      - name: Delete old NDLL's
         run: |
           rm -rf ndll
           mkdir ndll
-          rm -rf templates/bin/hl/*/
 
       - name: Download Android-NDLL artifact
         uses: actions/download-artifact@v8
@@ -49,12 +48,6 @@ jobs:
         with:
           name: Linux64-NDLL
           path: ndll/Linux64
-
-      - name: Download Linux64-Hashlink artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: Linux64-Hashlink
-          path: templates/bin/hl/Linux64
 
       - name: Download Mac64-NDLL artifact
         uses: actions/download-artifact@v8
@@ -79,12 +72,6 @@ jobs:
         with:
           name: Windows-NDLL
           path: ndll/Windows
-
-      - name: Download Windows64-Hashlink artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: Windows64-Hashlink
-          path: templates/bin/hl/Windows64
 
       - name: Download Miscellaneous artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -48,12 +48,6 @@ jobs:
           name: Linux64-NDLL
           path: ndll/Linux64
 
-      - name: Download Linux64-Hashlink artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: Linux64-Hashlink
-          path: templates/bin/hl/Linux64
-
       - name: Download Mac64-NDLL artifact
         uses: actions/download-artifact@v8
         with:
@@ -77,12 +71,6 @@ jobs:
         with:
           name: Windows-NDLL
           path: ndll/Windows
-
-      - name: Download Windows64-Hashlink artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: Windows64-Hashlink
-          path: templates/bin/hl/Windows64
 
       - name: ZIP Repo
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,8 +27,7 @@ jobs:
           libegl1-mesa-dev libgl1-mesa-dev libibus-1.0-dev libdbus-1-dev libdecor-0-dev libudev-dev libgbm-dev libdrm-dev \
           libpng-dev libturbojpeg-dev libvorbis-dev libopenal-dev libsdl2-dev libglu1-mesa-dev libmbedtls-dev libuv1-dev libsqlite3-dev \
           libx11-dev libxext-dev libxfixes-dev libxi-dev libxinerama-dev libxkbcommon-dev libxcursor-dev libxrandr-dev libxss-dev libxt-dev libxtst-dev libxv-dev libxxf86vm-dev \
-          libpulse-dev libasound2-dev libpipewire-0.3-dev \
-          g++-multilib gcc-multilib
+          libpulse-dev libasound2-dev libpipewire-0.3-dev
 
       - name: Install Haxe dependencies
         run: |
@@ -50,19 +49,9 @@ jobs:
       - name: Rebuild Lime (x86_64)
         run: haxelib run lime rebuild linux -64 -nocolor -eval
 
-      - name: Rebuild Lime (Hashlink)
-        run: haxelib run lime rebuild hl -nocolor
-
       - name: Upload Artifact (ndll/Linux64)
         uses: actions/upload-artifact@v7.0.0
         with:
           name: Linux64-NDLL
           path: ndll/Linux64
-          if-no-files-found: error
-
-      - name: Upload Artifact (templates/bin/hl/Linux64)
-        uses: actions/upload-artifact@v7
-        with:
-          name: Linux64-Hashlink
-          path: templates/bin/hl/Linux64
           if-no-files-found: error

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Rebuild Lime (x86)
         run: haxelib run lime rebuild windows -32 -nocolor -eval
 
-      - name: Rebuild Lime (Hashlink)
-        run: haxelib run lime rebuild hl -nocolor -eval
-
       - name: Upload Artifact (ndll/Windows64)
         uses: actions/upload-artifact@v7.0.0
         with:
@@ -56,11 +53,4 @@ jobs:
         with:
           name: Windows-NDLL
           path: ndll/Windows
-          if-no-files-found: error
-
-      - name: Upload Artifact (templates/bin/hl/Windows64)
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: Windows64-Hashlink
-          path: templates/bin/hl/Windows64
           if-no-files-found: error


### PR DESCRIPTION
Since HashLink got removed from the fork, I had to remove them from the workflows, so it won't give out any errors.

The other reason why I'm doing this is because some people still using github workflows instead of their actual os machine.